### PR TITLE
WIP: Update mattermost.rb for 3.5.1

### DIFF
--- a/attributes/mattermost.rb
+++ b/attributes/mattermost.rb
@@ -1,4 +1,4 @@
-default['mattermost']['package']['url'] = "https://releases.mattermost.com/3.5.1/mattermost-enterprise-3.5.1-linux-amd64.tar.gz"
+default['mattermost']['package']['url'] = "https://releases.mattermost.com/3.5.1/mattermost-3.5.1-linux-amd64.tar.gz"
 default['mattermost']['package']['checksum'] = "0aa376254b74c32672118e304dd931d507968209f44cb5ca4099c8cc5b511699"
 
 default['mattermost']['config']['install_path'] = "/opt" # installs to /opt/mattermost

--- a/attributes/mattermost.rb
+++ b/attributes/mattermost.rb
@@ -1,4 +1,4 @@
-default['mattermost']['package']['url'] = "https://releases.mattermost.com/3.5.0/mattermost-enterprise-3.5.0-linux-amd64.tar.gz"
+default['mattermost']['package']['url'] = "https://releases.mattermost.com/3.5.1/mattermost-enterprise-3.5.1-linux-amd64.tar.gz"
 default['mattermost']['package']['checksum'] = "0aa376254b74c32672118e304dd931d507968209f44cb5ca4099c8cc5b511699"
 
 default['mattermost']['config']['install_path'] = "/opt" # installs to /opt/mattermost


### PR DESCRIPTION
Submitting a pull request to update to Mattermost 3.5.1, [changelog can be found here](https://docs.mattermost.com/administration/changelog.html#release-v3-5-1).

Marking as a WIP as I wasn't sure which checksum entry does this line refer to

```
 default['mattermost']['package']['checksum'] = "0aa376254b74c32672118e304dd931d507968209f44cb5ca4099c8cc5b511699"
```

I assumed it might have been the md5 sum, but didn't seem like it