### PR TITLE
Feature/centos

### DIFF
--- a/attributes/database.rb
+++ b/attributes/database.rb
@@ -1,3 +1,4 @@
+default['mattermost']['database']['install_mysql'] = false # make MySQL install/config optional
 default['mattermost']['database']['remote'] = false
 default['mattermost']['database']['mysql_root'] = 'password'
 default['mattermost']['database']['hostname'] = '127.0.0.1'

--- a/attributes/mattermost.rb
+++ b/attributes/mattermost.rb
@@ -3,5 +3,6 @@ default['mattermost']['package']['checksum'] = "0aa376254b74c32672118e304dd931d5
 
 default['mattermost']['config']['install_path'] = "/opt" # installs to /opt/mattermost
 default['mattermost']['config']['user'] = "mattermost"
+default['mattermost']['config']['group'] = "mattermost"
 default['mattermost']['config']['data_dir'] = "/mattermost/data"
 default['mattermost']['config']['server_name'] = "localhost"

--- a/chefignore
+++ b/chefignore
@@ -93,3 +93,7 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+# Kitchen #
+###########
+.kitchen*

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,14 +4,14 @@ maintainer_email 'kyle.corupe@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures mattermost http://mattermost.com'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.7'
+version          '0.1.8'
 
-supports 'ubuntu'
+supports 'ubuntu', 'rhel', 'centos'
 
 depends 'apt'
 depends 'ark'
 depends 'database'
-depends 'mysql', '~> 6.0'
+depends 'mysql', '~> 8.2.0'
 depends 'mysql2_chef_gem'
 
 source_url 'https://github.com/verifi-inc/mattermost' if respond_to?(:source_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,12 +35,23 @@ template "#{node['mattermost']['config']['install_path']}/mattermost/config/conf
   notifies :restart, 'service[mattermost]'
 end
 
-template '/etc/init/mattermost.conf' do
-  source 'mattermost.conf.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-  notifies :restart, 'service[mattermost]'
+case node['platform_family']
+when 'debian'
+  template '/etc/init/mattermost.conf' do
+    source 'mattermost.conf.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, 'service[mattermost]'
+  end
+when 'rhel'
+  template '/etc/systemd/system/mattermost.service' do
+    source 'mattermost.service.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, 'service[mattermost]'
+  end
 end
 
 service 'mattermost' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,8 @@ directory node['mattermost']['config']['data_dir'] do
   action :create
 end
 
-include_recipe 'mattermost::database'
+include_recipe 'mattermost::database' if node['mattermost']['database']['install_mysql']
+
 
 template "#{node['mattermost']['config']['install_path']}/mattermost/config/config.json" do
   source 'config.json.erb'

--- a/templates/default/mattermost.service.erb
+++ b/templates/default/mattermost.service.erb
@@ -1,0 +1,12 @@
+[Service]
+ExecStart=<%= node['mattermost']['config']['install_path'] %>/mattermost/bin/platform
+WorkingDirectory=<%= node['mattermost']['config']['install_path'] %>/mattermost
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=mattermost
+User=<%= node['mattermost']['config']['user'] %>
+Group=<%= node['mattermost']['config']['group'] %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add support for CentOS/RHEL based distributions

Also only includes mattermost::database if node['mattermost']['database']['install_mysql'] == true.  We don't want this recipe handling any sort of database configuration as we do that in another recipe.